### PR TITLE
No intention to merge: Add insert_before, insert_after, and swap to collections.OrderedDict.

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -216,6 +216,27 @@ class OrderedDict(dict):
             first.prev = soft_link
             root.next = link
 
+    def _insert_between(self, prev_link, next_link, key, value):
+        self.__map[key] = link = prev_link.next = next_link.prev = _Link()
+        link.prev, link.next, link.key = prev_link, next_link, key
+        dict.__setitem__(self, key, value)
+
+    def insert_before(self, ref_key, key, value):
+        next_link = self.__map[ref_key]
+        self._insert_between(next_link.prev, next_link, key, value)
+
+    def insert_after(self, ref_key, key, value):
+        prev_link = self.__map[ref_key]
+        self._insert_between(prev_link, prev_link.next, key, value)
+
+    def swap(self, key1, key2):
+        link1, link2 = map(self.__map.__getitem__, (key1, key2))
+        prev1, next1, prev2, next2 = link1.prev, link1.next, link2.prev, link2.next
+        (link1.prev, link1.next, prev1.next, next1.prev,
+         link2.prev, link2.next, prev2.next, prev2.prev) = (
+            prev2, next2, link2, link2, prev1, next1, link1, link1
+        )
+
     def __sizeof__(self):
         sizeof = _sys.getsizeof
         n = len(self) + 1                       # number of links including root

--- a/Objects/clinic/odictobject.c.h
+++ b/Objects/clinic/odictobject.c.h
@@ -347,4 +347,190 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7d8206823bb1f419 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(OrderedDict_insert_before__doc__,
+"insert_before($self, /, sub_key, key, value)\n"
+"--\n"
+"\n"
+"Insert a key before the sub_key.");
+
+#define ORDEREDDICT_INSERT_BEFORE_METHODDEF    \
+    {"insert_before", _PyCFunction_CAST(OrderedDict_insert_before), METH_FASTCALL|METH_KEYWORDS, OrderedDict_insert_before__doc__},
+
+static PyObject *
+OrderedDict_insert_before_impl(PyODictObject *self, PyObject *sub_key,
+                               PyObject *key, PyObject *value);
+
+static PyObject *
+OrderedDict_insert_before(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 3
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        Py_hash_t ob_hash;
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_hash = -1,
+        .ob_item = { &_Py_ID(sub_key), &_Py_ID(key), &_Py_ID(value), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"sub_key", "key", "value", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "insert_before",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[3];
+    PyObject *sub_key;
+    PyObject *key;
+    PyObject *value;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
+            /*minpos*/ 3, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    sub_key = args[0];
+    key = args[1];
+    value = args[2];
+    return_value = OrderedDict_insert_before_impl((PyODictObject *)self, sub_key, key, value);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(OrderedDict_insert_after__doc__,
+"insert_after($self, /, sub_key, key, value)\n"
+"--\n"
+"\n"
+"Insert a key after the sub_key.");
+
+#define ORDEREDDICT_INSERT_AFTER_METHODDEF    \
+    {"insert_after", _PyCFunction_CAST(OrderedDict_insert_after), METH_FASTCALL|METH_KEYWORDS, OrderedDict_insert_after__doc__},
+
+static PyObject *
+OrderedDict_insert_after_impl(PyODictObject *self, PyObject *sub_key,
+                              PyObject *key, PyObject *value);
+
+static PyObject *
+OrderedDict_insert_after(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 3
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        Py_hash_t ob_hash;
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_hash = -1,
+        .ob_item = { &_Py_ID(sub_key), &_Py_ID(key), &_Py_ID(value), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"sub_key", "key", "value", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "insert_after",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[3];
+    PyObject *sub_key;
+    PyObject *key;
+    PyObject *value;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
+            /*minpos*/ 3, /*maxpos*/ 3, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    sub_key = args[0];
+    key = args[1];
+    value = args[2];
+    return_value = OrderedDict_insert_after_impl((PyODictObject *)self, sub_key, key, value);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(OrderedDict_swap__doc__,
+"swap($self, /, sub_key, key)\n"
+"--\n"
+"\n"
+"Swap two keys.");
+
+#define ORDEREDDICT_SWAP_METHODDEF    \
+    {"swap", _PyCFunction_CAST(OrderedDict_swap), METH_FASTCALL|METH_KEYWORDS, OrderedDict_swap__doc__},
+
+static PyObject *
+OrderedDict_swap_impl(PyODictObject *self, PyObject *sub_key, PyObject *key);
+
+static PyObject *
+OrderedDict_swap(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 2
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        Py_hash_t ob_hash;
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_hash = -1,
+        .ob_item = { &_Py_ID(sub_key), &_Py_ID(key), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"sub_key", "key", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "swap",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[2];
+    PyObject *sub_key;
+    PyObject *key;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
+            /*minpos*/ 2, /*maxpos*/ 2, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    sub_key = args[0];
+    key = args[1];
+    return_value = OrderedDict_swap_impl((PyODictObject *)self, sub_key, key);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=a35382c2b0ac9603 input=a9049054013a1b77]*/


### PR DESCRIPTION
This PR updates OrderedDict’s C implementation, and adds insert_before, insert_after, and swap, which are discussed in the thread below.
https://discuss.python.org/t/insert-swap-get-by-index-for-ordereddict/52375/5

from collections import OrderedDict
d = OrderedDict({i:i for i in range(10)})
d = OrderedDict(a=1, b=2, c=3)
a = d.copy()
a.insert_before('b', 'x', 0)
print(dict(a))
b = d.copy()
b.insert_after('b', 'x', 0)
print(dict(b))
d.swap('a', 'c')
print(dict(d))
